### PR TITLE
Fix separator in regex for Windows

### DIFF
--- a/src/processors/directive.ts
+++ b/src/processors/directive.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 Canva Inc. All Rights Reserved.
 
 import * as camelcase from 'camelcase';
-import { escapeRegExp } from 'lodash';
+import escapeRegExp = require('lodash.escaperegexp');
 import { OptionsV2, parseStringPromise as xml2js } from 'xml2js';
 import { DependencyTree, FileToDeps, Path } from '../';
 import { FileProcessor } from '../file_processor';

--- a/src/processors/feature.ts
+++ b/src/processors/feature.ts
@@ -2,7 +2,7 @@
 
 import { messages } from 'cucumber-messages';
 import * as gherkin from 'gherkin';
-import { escapeRegExp } from 'lodash';
+import escapeRegExp = require('lodash.escaperegexp');
 import * as path from 'path';
 import * as ts from 'typescript';
 import { FileToDeps, Path } from '../';


### PR DESCRIPTION
On Windows, running the E2E test for the Desktop App on Windows will fails:
```
SyntaxError: Invalid regular expression: /([^\]+)\.stories\.tsx?$/: Unterminated character class
    at new RegExp (<anonymous>)
    at Object.<anonymous> (node_modules\@canva\dependency-tree\dist\processors\feature.js:17:25)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (node_modules\@canva\dependency-tree\dist\file_processor.js:7:17)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
```

# Changelog
#### Change
- Escape the backslash in the regex for Windows