### PR TITLE
gather to accept optional files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canva/dependency-tree",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Calculates a dependency tree for set of files",
   "main": "dist/index.js",
   "author": "Canva Pty Ltd",

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,8 +157,11 @@ export class DependencyTree {
    * Built-in (Node) and package dependencies are ignored.
    */
   public async gather({
+    // The files to gather dependencies for
+    // by default globbing is used to find files from rootDirs
+    filesToProcess,
     batchSize = 10,
-  }: { batchSize?: number } = {}): Promise<{
+  }: { batchSize?: number; filesToProcess?: readonly string[] } = {}): Promise<{
     missing: FileToDeps;
     resolved: FileToDeps;
   }> {
@@ -170,7 +173,7 @@ export class DependencyTree {
 
     const fileToDeps: FileToDeps = new Map();
     const missing: FileToDeps = new Map();
-    const files = this.getFiles();
+    const files = filesToProcess ?? this.getFiles();
     info(`Found a total of ${files.length} source files`);
 
     const getDepsForFilesTasks = files.map((file: string) => async () => {


### PR DESCRIPTION
I am looking at improving efficiency of our find affected files and I think we can have a big win by adopting multithreading.
At the beginning I am looking at adding multithreading in this library but it turns out to be very difficult. Because it accepts a function parameter `transformReference` while function can not be passed to another thread.
As a consequence, I may work on applying multithreading to our usage and that requires `gather` function to accept a `files` parameter so that we can collect files first, divided them and run them in parallel.