### PR TITLE
gather to accept allFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canva/dependency-tree",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Calculates a dependency tree for set of files",
   "main": "dist/index.js",
   "author": "Canva Pty Ltd",

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,15 @@ export class DependencyTree {
     // The files to gather dependencies for
     // by default globbing is used to find files from rootDirs
     filesToProcess,
+    // All files collected
+    // by default globbing is used to find files from rootDirs
+    allFilesToProcess,
     batchSize = 10,
-  }: { batchSize?: number; filesToProcess?: readonly string[] } = {}): Promise<{
+  }: {
+    batchSize?: number;
+    filesToProcess?: readonly string[];
+    allFilesToProcess?: readonly string[];
+  } = {}): Promise<{
     missing: FileToDeps;
     resolved: FileToDeps;
   }> {
@@ -173,12 +180,17 @@ export class DependencyTree {
 
     const fileToDeps: FileToDeps = new Map();
     const missing: FileToDeps = new Map();
-    const files = filesToProcess ?? this.getFiles();
+    const allFiles = allFilesToProcess ?? this.getFiles();
+    const files = filesToProcess ?? allFiles;
     info(`Found a total of ${files.length} source files`);
 
     const getDepsForFilesTasks = files.map((file: string) => async () => {
       info('Scanning %s', file);
-      const importedFiles = await this.getImportedFiles(file, missing, files);
+      const importedFiles = await this.getImportedFiles(
+        file,
+        missing,
+        allFiles,
+      );
       fileToDeps.set(file, importedFiles);
     });
 
@@ -289,7 +301,7 @@ export class DependencyTree {
    *
    * @returns {string[]} An array of found files (absolute paths)
    */
-  private getFiles(): readonly Path[] {
+  getFiles(): readonly Path[] {
     const supportedFileTypes = new Set(
       this.fileProcessors.reduce(
         (acc, processor) => [...acc, ...processor.supportedFileTypes()],


### PR DESCRIPTION
When run in parallel, we get all files to process at the beginning, distribute it into few array evenly and call `gather` with that.
However, since processor need have access to all files instead of just part of them so that they can see whether some files are missing or not, we have to pass an additional argument for that.